### PR TITLE
This patch fixes the dependency on "common" for all charts

### DIFF
--- a/charts/layer0_describo/Chart.lock
+++ b/charts/layer0_describo/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:20b9ad37d0c29cf13eabc3b9783d4f79c552ae28f70544d74c7deed692937365
-generated: "2022-08-12T18:43:13.077135333+02:00"
+digest: sha256:812d36067d088cad7eeb94005e23171d9532f1dc2b8f23bd633db1b795c4a577
+generated: "2023-02-07T10:30:53.443729026+01:00"

--- a/charts/layer0_describo/Chart.yaml
+++ b/charts/layer0_describo/Chart.yaml
@@ -25,3 +25,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer0-describo-common
+

--- a/charts/layer0_helper_describo_token_updater/Chart.lock
+++ b/charts/layer0_helper_describo_token_updater/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-10-07T13:50:50.913724197+02:00"
+digest: sha256:907f03fdcae7108b8137782291baf28aad5dff00fe221ee3bb3bebd8d1101c9c
+generated: "2023-02-07T10:30:53.980764318+01:00"

--- a/charts/layer0_helper_describo_token_updater/Chart.yaml
+++ b/charts/layer0_helper_describo_token_updater/Chart.yaml
@@ -23,3 +23,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer0-helper-describo-token-updater-common
+

--- a/charts/layer0_web/Chart.lock
+++ b/charts/layer0_web/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:49:52.195218932+01:00"
+digest: sha256:9f1061b59aef21bbca3bc05796009e900a75e94f1b37107e92b756f2c0a6e1d7
+generated: "2023-02-07T10:30:54.433292998+01:00"

--- a/charts/layer0_web/Chart.yaml
+++ b/charts/layer0_web/Chart.yaml
@@ -19,3 +19,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer0-web-common
+

--- a/charts/layer1_port_openscienceframework/Chart.lock
+++ b/charts/layer1_port_openscienceframework/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:23.676871925+01:00"
+digest: sha256:7aaa9dc5d2b77fe20b6c86434b0c1b5ec1755a923fca94ab95b35f07eec006e8
+generated: "2023-02-07T10:30:54.931573465+01:00"

--- a/charts/layer1_port_openscienceframework/Chart.yaml
+++ b/charts/layer1_port_openscienceframework/Chart.yaml
@@ -20,3 +20,6 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer1-port-openscienceframewor-common
+
+

--- a/charts/layer1_port_owncloud/Chart.lock
+++ b/charts/layer1_port_owncloud/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:24.722062884+01:00"
+digest: sha256:f9388dc66957a72d1d42857c8c87b9e4c2c81fb5fcdc5829b366219fa64c77bd
+generated: "2023-02-07T10:30:55.413462484+01:00"

--- a/charts/layer1_port_owncloud/Chart.yaml
+++ b/charts/layer1_port_owncloud/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer1-port-owncloud-common
+

--- a/charts/layer1_port_reva/Chart.lock
+++ b/charts/layer1_port_reva/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:25.763832015+01:00"
+digest: sha256:c45fe9bebe36f65d76dc5793030e0ad762dc46d290d98837e2a85cc6e6329914
+generated: "2023-02-07T10:30:55.892945969+01:00"

--- a/charts/layer1_port_reva/Chart.yaml
+++ b/charts/layer1_port_reva/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer1-port-reva-common
+

--- a/charts/layer1_port_zenodo/Chart.lock
+++ b/charts/layer1_port_zenodo/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:26.814803658+01:00"
+digest: sha256:d1d50002fef4797c2a48d9d32c63033f562681492a57c98311330067b5359984
+generated: "2023-02-07T10:30:56.387781762+01:00"

--- a/charts/layer1_port_zenodo/Chart.yaml
+++ b/charts/layer1_port_zenodo/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer1-port-zenodo-common
+

--- a/charts/layer2_exporter_service/Chart.lock
+++ b/charts/layer2_exporter_service/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:27.846303208+01:00"
+digest: sha256:a6c0de64f7566cd8e27dbc5e3fcf34a3df54d6333bff2e6cb61b8c172bddc240
+generated: "2023-02-07T10:30:56.892693816+01:00"

--- a/charts/layer2_exporter_service/Chart.yaml
+++ b/charts/layer2_exporter_service/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer2-exporter-service-common
+

--- a/charts/layer2_metadata_service/Chart.lock
+++ b/charts/layer2_metadata_service/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:28.919473827+01:00"
+digest: sha256:318af01b93c9de85b7a5c9ebd15321e6eea000ce4d817337cfb8b083a1f6e92e
+generated: "2023-02-07T10:30:57.413843137+01:00"

--- a/charts/layer2_metadata_service/Chart.yaml
+++ b/charts/layer2_metadata_service/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer2-metadata-service-common
+

--- a/charts/layer2_port_service/Chart.lock
+++ b/charts/layer2_port_service/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:30.095492834+01:00"
+digest: sha256:dca3d3ef6fede10aab2defdabecdff2205a5bd66c7b36d1441f98635d4b84e37
+generated: "2023-02-07T10:30:57.939050904+01:00"

--- a/charts/layer2_port_service/Chart.yaml
+++ b/charts/layer2_port_service/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer2-port-service-common
+

--- a/charts/layer3_research_manager/Chart.lock
+++ b/charts/layer3_research_manager/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:31.168661614+01:00"
+digest: sha256:96a625dec9b5cc24195264a79968fd43a4a7199bfd0b4e22c994e9e48736a6c2
+generated: "2023-02-07T10:30:58.462751504+01:00"

--- a/charts/layer3_research_manager/Chart.yaml
+++ b/charts/layer3_research_manager/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer3-research-manager-common
+

--- a/charts/layer3_token_storage/Chart.lock
+++ b/charts/layer3_token_storage/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 0.1.2
-digest: sha256:aeededd4569b2943863da6b13e1fb4f4476221c651ddd5cf7011e65504876e78
-generated: "2022-02-14T11:59:32.216049963+01:00"
+digest: sha256:d1c8c0cbbca95a7e19dbef5c25f6422bf2c632f5972f682e44d4f70bb8ca4b74
+generated: "2023-02-07T10:30:58.971766018+01:00"

--- a/charts/layer3_token_storage/Chart.yaml
+++ b/charts/layer3_token_storage/Chart.yaml
@@ -20,3 +20,5 @@ dependencies:
   - name: common
     version: ^0.1.0
     repository: file://../common
+    alias: layer3-token-storage-common
+

--- a/charts/postgresql/Chart.lock
+++ b/charts/postgresql/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://charts/common
   version: 1.10.3
-digest: sha256:2d9d2207d24a9279384804ccc4b28ad745a86fca98d37385dc185498a0eb044f
-generated: "2022-10-07T13:47:26.676065606+02:00"
+digest: sha256:82aaf79ebedf82345360ed9d2271ced861bce18bf02165041364808bc5c23c3f
+generated: "2023-02-07T10:30:59.478748345+01:00"

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -6,6 +6,7 @@ dependencies:
 - name: common
   repository: file://charts/common
   version: 1.x.x
+  alias: postgresql-common
 description: Chart for PostgreSQL, an object-relational database management system
   (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 home: https://github.com/bitnami/charts/tree/master/bitnami/postgresql

--- a/charts/redis-cluster/Chart.lock
+++ b/charts/redis-cluster/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://charts/common
   version: 1.16.0
-digest: sha256:c16eb66e67456e7d188f71098126ced6ad614ab6e8014a24742bd761f508eda0
-generated: "2022-08-18T16:00:05.215566553+02:00"
+digest: sha256:8cbf195631894434137a5801072c21fbcff43915de298ab2664725c5492fa7d0
+generated: "2023-02-07T10:31:00.441718631+01:00"

--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -7,6 +7,7 @@ dependencies:
   repository: file://charts/common
   tags:
   - bitnami-common
+  alias: redis-cluster-common
   version: 1.x.x
 description: Redis(R) is an open source, scalable, distributed in-memory cache for
   applications. It can be used to store and serve data in the form of strings, hashes,

--- a/charts/redis/Chart.lock
+++ b/charts/redis/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: common
   repository: file://charts/common
   version: 1.16.0
-digest: sha256:c16eb66e67456e7d188f71098126ced6ad614ab6e8014a24742bd761f508eda0
-generated: "2022-10-07T13:50:47.90584524+02:00"
+digest: sha256:4ada3eb952477c2d0cedb8b58c4dd4351576124c08e2b597bb8d7a85a821d0b3
+generated: "2023-02-07T10:50:01.265240461+01:00"

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -7,6 +7,7 @@ dependencies:
   repository: file://charts/common
   tags:
   - bitnami-common
+  alias: redis-common
   version: 1.x.x
 description: Redis(R) is an open source, advanced key-value store. It is often referred
   to as a data structure server since keys can contain strings, hashes, lists, sets


### PR DESCRIPTION
If you want to reuse a chart multiple times you have to add an alias for it.

This is according to https://helm.sh/docs/helm/helm_dependency/

And indeed it makes it possible to install the charts with helm on k8s 1.25, which is tested in SUNET k8s cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed

