### PR TITLE
Allow local minikube environment with nextcloud

### DIFF
--- a/charts/all/Chart.lock
+++ b/charts/all/Chart.lock
@@ -44,5 +44,11 @@ dependencies:
 - name: redis
   repository: file://../redis
   version: 16.13.2
-digest: sha256:643d0156dd67144f1b4fddf70d07155fbe6fc13ae31c06f0ef402f39b6580887
-generated: "2023-01-16T12:41:35.854+01:00"
+- name: nextcloud
+  repository: https://nextcloud.github.io/helm/
+  version: 3.5.4
+- name: owncloud
+  repository: https://owncloud-docker.github.io/helm-charts
+  version: 0.4.1
+digest: sha256:f1b7af01ca54c4afc63a5dd344e4b8ca30deb9e8312609c1397015dc0886c630
+generated: "2023-03-28T09:29:07.381386431+02:00"

--- a/charts/all/Chart.yaml
+++ b/charts/all/Chart.yaml
@@ -108,3 +108,7 @@ dependencies:
     version: ^3.5.2
     repository: https://nextcloud.github.io/helm/
     condition: feature.nextcloud
+  - name: owncloud
+    version: ^0.4.1
+    repository: https://owncloud-docker.github.io/helm-charts
+    condition: feature.owncloud

--- a/charts/all/Chart.yaml
+++ b/charts/all/Chart.yaml
@@ -104,3 +104,7 @@ dependencies:
     condition: feature.redis
     tags:
       - storage
+  - name: nextcloud
+    version: ^3.5.2
+    repository: https://nextcloud.github.io/helm/
+    condition: feature.nextcloud

--- a/charts/all/values.yaml
+++ b/charts/all/values.yaml
@@ -32,6 +32,7 @@ namespace:
 feature:
   jaeger: false
   redis: true
+  nextcloud: false
 layer0-web:
   enabled: true
   environment:

--- a/charts/all/values.yaml
+++ b/charts/all/values.yaml
@@ -33,6 +33,7 @@ feature:
   jaeger: false
   redis: true
   nextcloud: false
+  owncloud: false
 layer0-web:
   enabled: true
   environment:

--- a/charts/layer1_port_owncloud/templates/configmap.yaml
+++ b/charts/layer1_port_owncloud/templates/configmap.yaml
@@ -29,4 +29,3 @@ data:
   OWNCLOUD_INTERNAL_INSTALLATION_URL: {{ .INTERNAL_ADDRESS | quote }}
   {{ end }}
 {{- end }}
-{{- end }}

--- a/charts/layer1_port_owncloud/templates/configmap.yaml
+++ b/charts/layer1_port_owncloud/templates/configmap.yaml
@@ -22,4 +22,11 @@ data:
   OWNCLOUD_INSTALLATION_URL: {{ .ADDRESS | quote }}
   OWNCLOUD_OAUTH_CLIENT_SECRET: {{ .OAUTH_CLIENT_SECRET | quote }}
   SERVICENAME: {{ .name | replace "." "-" | replace ":" "-" }}
+  {{ if not .INTERNAL_ADDRESS }}
+  OWNCLOUD_INTERNAL_INSTALLATION_URL: {{ .ADDRESS | quote }}
+  {{ end }}
+  {{ if .INTERNAL_ADDRESS }}
+  OWNCLOUD_INTERNAL_INSTALLATION_URL: {{ .INTERNAL_ADDRESS | quote }}
+  {{ end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This patch's aim is to make it possible to run a fully local k8s environment using minikube with RDS embedded in an EFSS running in the same local k8s environment.

On one hand, it add a helm char for NextCloud to the all chart, disabled by default.

On the other, it adds the possibility of configuring NexCloud (or OwnCloud, or any other EFSS) with both an internal address, to access it from within the k8s environment, and an external address, to access it from the browser.