### PR TITLE
stable/layer0_describo, layer0_web, layer1_port_openscienceframework, layer1_port_owncloud, layer1_port_zenodo: Use secrets instead of values.yaml

### DIFF
--- a/charts/all/Chart.yaml
+++ b/charts/all/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A single chart for installing whole sciebo rds ecosystem.
 name: all
-version: 0.2.10
+version: 0.3.0
 home: https://www.research-data-services.org/
 type: application
 keywords:

--- a/charts/layer0_describo/templates/deployment.yaml
+++ b/charts/layer0_describo/templates/deployment.yaml
@@ -49,6 +49,17 @@ spec:
               mountPath: /srv/profiles/type-definitions.json
               subPath: type-definitions.json
               readOnly: true
+          env:
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: describo-pg-passwd
+                key: postgresql-password
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: admin-passwd
+                key: passwd
           envFrom:
           - configMapRef:
               name: mservice

--- a/charts/layer0_web/templates/deployment.yaml
+++ b/charts/layer0_web/templates/deployment.yaml
@@ -35,6 +35,26 @@ spec:
               mountPath: /srv/domains.json
               subPath: domains.json
               readOnly: true
+{{- if.Values.global.domains }}
+          env:
+  {{- range $domain := .Values.global.domains }}
+    {{- $name := $domain.name -}}
+    {{- $upper_name := upper $name | replace "." "_" -}}
+    {{- $lower_name := lower $name | replace "." "-" -}}
+    {{- $client_id := printf "%s_%s" $upper_name "OAUTH_CLIENT_ID" }}
+    {{- $client_secret := printf "%s_%s" $upper_name "OAUTH_CLIENT_SECRET" }}
+          - name: {{ $client_id }}
+            valueFrom:
+              secretKeyRef:
+                name: layer1-port-owncloud-{{ $lower_name }}
+                key: oauth-client-id
+          - name: {{ $client_secret }}
+            valueFrom:
+              secretKeyRef:
+                name: layer1-port-owncloud-{{ $lower_name }}
+                key: oauth-client-secret
+  {{- end }}
+{{- end }}
           envFrom:
           - configMapRef:
               name: mservice

--- a/charts/layer1_port_openscienceframework/templates/deployment.yaml
+++ b/charts/layer1_port_openscienceframework/templates/deployment.yaml
@@ -23,6 +23,17 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ template "layer1_port_openscienceframework.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: OAUTH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: osf-client
+                key: osf-client-id
+          - name: OAUTH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: osf-client
+                key: osf-client-secret
           envFrom:
           - configMapRef:
               name: mservice

--- a/charts/layer1_port_owncloud/templates/deployment.yaml
+++ b/charts/layer1_port_owncloud/templates/deployment.yaml
@@ -37,6 +37,17 @@ spec:
         - name: {{ $.Chart.Name }}
           image: {{ template "layer1_port_owncloud.image"  $ }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          env:
+          - name: OWNCLOUD_OAUTH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: layer1-port-owncloud-{{ .name | replace "." "-" | replace ":" "-" }}
+                key: "oauth-client-id"
+          - name: OWNCLOUD_OAUTH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: layer1-port-owncloud-{{ .name | replace "." "-" | replace ":" "-" }}
+                key: "oauth-client-secret"
           envFrom:
           - configMapRef:
               name: mservice

--- a/charts/layer1_port_zenodo/templates/deployment.yaml
+++ b/charts/layer1_port_zenodo/templates/deployment.yaml
@@ -23,6 +23,17 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ template "layer1_port_zenodo.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: OAUTH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: zenodo-client
+                key: zenodo-client-id
+          - name: OAUTH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: zenodo-client
+                key: zenodo-client-secret
           envFrom:
           - configMapRef:
               name: mservice


### PR DESCRIPTION

#### What this PR does / why we need it:
This patch makes it possible to use native kubernetes secrets rather than having all secrets in the values.yaml file
The following secrets should be in the namespace where rds is running:

describo-pg-passwd
                key: postgresql-password

admin-passwd
                key: passwd

osf-client
                key: osf-client-id
                key: osf-client-secret

zenodo-client
                key: zenodo-client-id
                key: zenodo-client-secret

layer1-port-owncloud-{{ $lower_name }}
                key: oauth-client-id
                key: oauth-client-secret


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
