### PR TITLE
stable/layer0_web: Handle all non-word characters

### DIFF
--- a/charts/all/Chart.yaml
+++ b/charts/all/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A single chart for installing whole sciebo rds ecosystem.
 name: all
-version: 0.3.0
+version: 0.3.1
 home: https://www.research-data-services.org/
 type: application
 keywords:

--- a/charts/all/Chart.yaml
+++ b/charts/all/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0"
+appVersion: ">0.2.5"
 description: A single chart for installing whole sciebo rds ecosystem.
 name: all
 version: 0.3.1

--- a/charts/layer0_web/templates/deployment.yaml
+++ b/charts/layer0_web/templates/deployment.yaml
@@ -39,8 +39,8 @@ spec:
           env:
   {{- range $domain := .Values.global.domains }}
     {{- $name := $domain.name -}}
-    {{- $upper_name := upper $name | replace "." "_" -}}
-    {{- $lower_name := lower $name | replace "." "-" -}}
+    {{- $upper_name := regexReplaceAll "\\W+" $name "_" | upper -}}
+    {{- $lower_name := regexReplaceAll "\\W+" $name "-" | lower -}}
     {{- $client_id := printf "%s_%s" $upper_name "OAUTH_CLIENT_ID" }}
     {{- $client_secret := printf "%s_%s" $upper_name "OAUTH_CLIENT_SECRET" }}
           - name: {{ $client_id }}


### PR DESCRIPTION
In the rds app for layer0_web we replace both dash and dot with underscore[0], we don't do that in the corresponding chart, resulting in a bug where the environment variable created will not match the one that is actually looked for in the application.

This patch will replace[1] all non word characters[2] with underscore (i.e. only [a-zA-Z0-9_] will remain).

I have subbmitted the corresponding patch for the rds application as well, to make sure we use the same scheme in both places to avoid further bugs like this[3].

Notes:
 0. https://github.com/Sciebo-RDS/Sciebo-RDS/blob/develop/RDS/layer0_ingress/web/server/src/app.py#L107
 1. https://github.com/Masterminds/sprig/blob/master/docs/strings.md#regexreplaceall-mustregexreplaceall
 2. https://yourbasic.org/golang/regexp-cheat-sheet/#character-classes
 3. https://github.com/Sciebo-RDS/Sciebo-RDS/pull/259

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
