### PR TITLE
add more customization options to connector instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,22 @@ The following table lists the most used configurable parameters of the Sciebo RD
 
 ##### Connector Branding
 
-Additionally, there a few parameters that can be used to "brand" a connector, e.g. show the logo of your branded owncloud instance, instead of the owncloud logo.
+Additionally, there a few parameters that can be used to "brand" a connector, e.g. show the logo of your branded owncloud instance, instead of the owncloud logo. None of these are required, as all connectors come with a default Displayname, Info- and HelpURL, Icon (Logo), Describo Profile. A "Go to project" button for published projects will only be available, if `PROJECT_LINK_TEMPLATE` is set.
 
 | Parameter                                              | Description                                                                      | Default / Example                                    |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `layer1-port-zenodo.environment.DISPLAYNAME`           |                                                                                  |                                                      |
 | `layer1-port-zenodo.environment.INFO_URL`              |                                                                          |                                                      |
-| `layer1-port-zenodo.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-zenodo.environment.HELP_URL`              |                                                                          |                                                      |
 | `layer1-port-zenodo.environment.ICON`                  | Path to Image File                                                       |                                                      |
 | `layer1-port-zenodo.environment.METADATA_Profile`      | Path to Describo Profile                                                 |                                                      |
-| `layer1-port-zenodo.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-zenodo.environment.PROJECT_LINK_TEMPLATE`               | A template string for URLs to published projects                         | "https://zenodo.org/record/${projectID}", ${projectID} will be replaced by the ID provided by the repository |
 | `layer1-port-openscienceframework.environment.DISPLAYNAME`           |                                                                          |                                                      |
 | `layer1-port-openscienceframework.environment.INFO_URL`              |                                                                          |                                                      |
-| `layer1-port-openscienceframework.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-openscienceframework.environment.HELP_URL`              |                                                                          |                                                      |
 | `layer1-port-openscienceframework.environment.ICON`                  | Path to Image File                                                       |                                                      |
 | `layer1-port-openscienceframework.environment.METADATA_Profile`      | Path to Describo Profile                                                 |                                                      |
-| `layer1-port-openscienceframework.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-openscienceframework.environment.PROJECT_LINK_TEMPLATE` | A template string for URLs to published projects                         | "https://osf.io/${projectID}", ${projectID} will be replaced by the ID provided by the repository |
 | `layer1-port-owncloud.environment.DISPLAYNAME`             |                                                                                  |                                                      |
 | `layer1-port-owncloud.environment.INFO_URL`                |                                                                                  |                                                      |
 | `layer1-port-owncloud.environment.HELP_URL`                |                                                                                  |                                                      |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,32 @@ The following table lists the most used configurable parameters of the Sciebo RD
 | `<component>.nodeSelector.*`                           |                                                                                  | {}                                                   |
 | `<component>.tolerations.*`                            |                                                                                  | []                                                   |
 | `<component>.affinity.*`                               |                                                                                  | {}                                                   |
+
+
+##### Connector Branding
+
+Additionally, there a few parameters that can be used to "brand" a connector, e.g. show the logo of your branded owncloud instance, instead of the owncloud logo.
+
+| Parameter                                              | Description                                                                      | Default / Example                                    |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `layer1-port-zenodo.environment.DISPLAYNAME`           |                                                                                  |                                                      |
+| `layer1-port-zenodo.environment.INFO_URL`              |                                                                          |                                                      |
+| `layer1-port-zenodo.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-zenodo.environment.ICON`                  | Path to Image File                                                       |                                                      |
+| `layer1-port-zenodo.environment.METADATA_Profile`      | Path to Describo Profile                                                 |                                                      |
+| `layer1-port-zenodo.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-openscienceframework.environment.DISPLAYNAME`           |                                                                          |                                                      |
+| `layer1-port-openscienceframework.environment.INFO_URL`              |                                                                          |                                                      |
+| `layer1-port-openscienceframework.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-openscienceframework.environment.ICON`                  | Path to Image File                                                       |                                                      |
+| `layer1-port-openscienceframework.environment.METADATA_Profile`      | Path to Describo Profile                                                 |                                                      |
+| `layer1-port-openscienceframework.environment.HELP_URL           `   |                                                                          |                                                      |
+| `layer1-port-owncloud.environment.DISPLAYNAME`             |                                                                                  |                                                      |
+| `layer1-port-owncloud.environment.INFO_URL`                |                                                                                  |                                                      |
+| `layer1-port-owncloud.environment.HELP_URL`                |                                                                                  |                                                      |
+| `layer1-port-owncloud.environment.ICON`                    | Path to Image File                                                               |                                                      |
+
+
 If you need more parameters, please take a look into the values.yaml of the corresponding service.
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following table lists the most used configurable parameters of the Sciebo RD
 
 ##### Connector Branding
 
-Additionally, there a few parameters that can be used to "brand" a connector, e.g. show the logo of your branded owncloud instance, instead of the owncloud logo. None of these are required, as all connectors come with a default Displayname, Info- and HelpURL, Icon (Logo), Describo Profile. A "Go to project" button for published projects will only be available, if `PROJECT_LINK_TEMPLATE` is set.
+Additionally, there a few parameters that can be used to "brand" a connector, e.g. show the logo of your branded owncloud instance, instead of the owncloud logo. None of these are required, as all connectors come with a default Displayname, Info- and HelpURL, Icon (Logo), Describo Profile. A "Go to project" button for published projects will only be available if `PROJECT_LINK_TEMPLATE` is set.
 
 | Parameter                                              | Description                                                                      | Default / Example                                    |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------- | ---------------------------------------------------- |

--- a/charts/layer1_port_openscienceframework/templates/configmap.yaml
+++ b/charts/layer1_port_openscienceframework/templates/configmap.yaml
@@ -8,3 +8,10 @@ data:
     OPENSCIENCEFRAMEWORK_ADDRESS: {{ .Values.environment.ADDRESS | quote }}
     OPENSCIENCEFRAMEWORK_API_ADDRESS: {{ .Values.environment.API_ADDRESS | quote }}
     OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_SECRET: {{ .Values.environment.OAUTH_CLIENT_SECRET | quote }}
+    OPENSCIENCEFRAMEWORK_DISPLAYNAME: {{ .Values.environment.DISPLAYNAME | quote }}
+    OPENSCIENCEFRAMEWORK_INFO_URL: {{ .Values.environment.INFO_URL | quote }}
+    OPENSCIENCEFRAMEWORK_HELP_URL: {{ .Values.environment.HELP_URL | quote }}
+    OPENSCIENCEFRAMEWORK_ICON: {{ .Values.environment.ICON | quote }}
+    OPENSCIENCEFRAMEWORK_METADATA_PROFILE: {{ .Values.environment.METADATA_PROFILE | quote }}
+    OPENSCIENCEFRAMEWORK_PROJECT_LINK_TEMPLATE: {{ .Values.environment.PROJECT_LINK_TEMPLATE | quote }}
+    

--- a/charts/layer1_port_openscienceframework/values.yaml
+++ b/charts/layer1_port_openscienceframework/values.yaml
@@ -52,3 +52,9 @@ environment:
   API_ADDRESS: https://api.test.osf.io/v2
   OAUTH_CLIENT_ID: ""
   OAUTH_CLIENT_SECRET: ""
+  DISPLAYNAME: ""
+  INFO_URL: ""
+  HELP_URL: ""
+  ICON: ""
+  METADATA_PROFILE: ""
+  PROJECT_LINK_TEMPLATE: ""

--- a/charts/layer1_port_owncloud/templates/configmap.yaml
+++ b/charts/layer1_port_owncloud/templates/configmap.yaml
@@ -21,6 +21,10 @@ data:
   OWNCLOUD_OAUTH_CLIENT_ID: {{ .OAUTH_CLIENT_ID | quote }}
   OWNCLOUD_INSTALLATION_URL: {{ .ADDRESS | quote }}
   OWNCLOUD_OAUTH_CLIENT_SECRET: {{ .OAUTH_CLIENT_SECRET | quote }}
+  OWNCLOUD_DISPLAYNAME: {{ .DISPLAYNAME | quote }}
+  OWNCLOUD_INFO_URL: {{ .INFO_URL | quote }}
+  OWNCLOUD_HELP_URL: {{ .HELP_URL | quote }}
+  OWNCLOUD_ICON: {{ .ICON | quote }}
   SERVICENAME: {{ .name | replace "." "-" | replace ":" "-" }}
   {{ if not .INTERNAL_ADDRESS }}
   OWNCLOUD_INTERNAL_INSTALLATION_URL: {{ .ADDRESS | quote }}

--- a/charts/layer1_port_owncloud/values.yaml
+++ b/charts/layer1_port_owncloud/values.yaml
@@ -32,6 +32,10 @@ ingress:
 
 environment:
   ADDRESS: "https://test-adress.de"
+  DISPLAYNAME: ""
+  INFO_URL: ""
+  HELP_URL: ""
+  ICON: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/layer1_port_zenodo/templates/configmap.yaml
+++ b/charts/layer1_port_zenodo/templates/configmap.yaml
@@ -2,8 +2,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: portzenodoconfig
-  namespace: {{ .Release.Namespace  }}
+  namespace: { { .Release.Namespace } }
 data:
-  ZENODO_OAUTH_CLIENT_ID: {{ .Values.environment.OAUTH_CLIENT_ID | quote }}
-  ZENODO_ADDRESS: {{ .Values.environment.ADDRESS | quote }}
-  ZENODO_OAUTH_CLIENT_SECRET: {{ .Values.environment.OAUTH_CLIENT_SECRET | quote }}
+  ZENODO_OAUTH_CLIENT_ID: { { .Values.environment.OAUTH_CLIENT_ID | quote } }
+  ZENODO_ADDRESS: { { .Values.environment.ADDRESS | quote } }
+  ZENODO_OAUTH_CLIENT_SECRET: { { .Values.environment.OAUTH_CLIENT_SECRET | quote } }
+  ZENODO_DISPLAYNAME: { { .Values.environment.DISPLAYNAME | quote } }
+  ZENODO_INFO_URL: { { .Values.environment.INFO_URL | quote } }
+  ZENODO_HELP_URL: { { .Values.environment.HELP_URL | quote } }
+  ZENODO_ICON: { { .Values.environment.ICON | quote } }
+  ZENODO_METADATA_PROFILE: { { .Values.environment.METADATA_PROFILE | quote } }
+  ZENODO_PROJECT_LINK_TEMPLATE: { { .Values.environment.PROJECT_LINK_TEMPLATE | quote } }

--- a/charts/layer1_port_zenodo/templates/configmap.yaml
+++ b/charts/layer1_port_zenodo/templates/configmap.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: portzenodoconfig
-  namespace: { { .Release.Namespace } }
+  namespace: {{ .Release.Namespace }}
 data:
-  ZENODO_OAUTH_CLIENT_ID: { { .Values.environment.OAUTH_CLIENT_ID | quote } }
-  ZENODO_ADDRESS: { { .Values.environment.ADDRESS | quote } }
-  ZENODO_OAUTH_CLIENT_SECRET: { { .Values.environment.OAUTH_CLIENT_SECRET | quote } }
-  ZENODO_DISPLAYNAME: { { .Values.environment.DISPLAYNAME | quote } }
-  ZENODO_INFO_URL: { { .Values.environment.INFO_URL | quote } }
-  ZENODO_HELP_URL: { { .Values.environment.HELP_URL | quote } }
-  ZENODO_ICON: { { .Values.environment.ICON | quote } }
-  ZENODO_METADATA_PROFILE: { { .Values.environment.METADATA_PROFILE | quote } }
-  ZENODO_PROJECT_LINK_TEMPLATE: { { .Values.environment.PROJECT_LINK_TEMPLATE | quote } }
+  ZENODO_OAUTH_CLIENT_ID: {{ .Values.environment.OAUTH_CLIENT_ID | quote }}
+  ZENODO_ADDRESS: {{ .Values.environment.ADDRESS | quote }}
+  ZENODO_OAUTH_CLIENT_SECRET: {{ .Values.environment.OAUTH_CLIENT_SECRET | quote }}
+  ZENODO_DISPLAYNAME: {{ .Values.environment.DISPLAYNAME | quote }}
+  ZENODO_INFO_URL: {{ .Values.environment.INFO_URL | quote }}
+  ZENODO_HELP_URL: {{ .Values.environment.HELP_URL | quote }}
+  ZENODO_ICON: {{ .Values.environment.ICON | quote }}
+  ZENODO_METADATA_PROFILE: {{ .Values.environment.METADATA_PROFILE | quote }}
+  ZENODO_PROJECT_LINK_TEMPLATE: {{ .Values.environment.PROJECT_LINK_TEMPLATE | quote }}

--- a/charts/layer1_port_zenodo/values.yaml
+++ b/charts/layer1_port_zenodo/values.yaml
@@ -22,14 +22,15 @@ service:
   port: 80
   targetPort: 8080
   annotations:
-     prometheus.io/scrape: 'true'
+    prometheus.io/scrape: "true"
 
 domain: localhost
 ingress:
   tls:
     secretName: sciebords-tls-public
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -47,7 +48,13 @@ tolerations: []
 
 affinity: {}
 
-environment: 
+environment:
   ADDRESS: https://sandbox.zenodo.org
   OAUTH_CLIENT_ID: ""
   OAUTH_CLIENT_SECRET: ""
+  DISPLAYNAME: ""
+  INFO_URL: ""
+  HELP_URL: ""
+  ICON: ""
+  METADATA_PROFILE: ""
+  PROJECT_LINK_TEMPLATE: ""


### PR DESCRIPTION
Add more customization options to `values.yml` for connector instances, e.g. set your own icon and displayname for a branded owncloud instance or nextcloud branding while using the owncloud connector.