### PR TITLE
layer1_port_openscienceframework/layer1_port_zenodo: Match environment variable names to what is used in python code

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,43 +25,43 @@ helm upgrade rds oci://harbor.uni-muenster.de/rds/all --install --values values.
 
 The following table lists the most used configurable parameters of the Sciebo RDS chart and their default values.
 
-| Parameter                                              | Description                                                                      | Default / Example                                    |
-| ------------------------------------------------------ | -------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `global.REDIS_HOST`                                    | This redis host will be used to store values. Redis-Cluster instance             | redis                                                |
-| `global.REDIS_PORT`                                    | This redis port will be used to store values. Redis-Cluster instance             | 6379                                                 |
-| `global.REDIS_HELPER_HOST`                             | This redis host will be used to store values. Standalone redis (Purpose: Pubsub) | redis                                                |
-| `global.REDIS_HELPER_HOST`                             | This redis port will be used to store values. Standalone redis (Purpose: Pubsub) | 6379                                                 |
-| `global.describo.api_secret`                           | This secret needs to be sent everytime you want to communicate with describo.    | XXX                                                  |
-| `global.describo.domain`                               | The domain where describo is located at.                                         | https://describo.localhost.org                       |
-| `global.rds.domain`                                    | Tehe omain where RDS Web is located at.                                          | https://app.localhost.org                            |
-| `global.ingress.tls.secretName`                        | The name of the tls secret within k8s.                                           | "sciebords-tls-public"                               |
-| `global.ingress.annotations`                           | Annotations for ingress. Will be merged with local annotations.                  | {}                                                   |
-| `global.storageClass`                                  | Can be used to set a global storageClass. Local values will not be overwrite.    | ""                                                   |
-| `layer1-port-zenodo.environment.ADDRESS`               |                                                                                  | https://sandbox.zenodo.org                           |
-| `layer1-port-zenodo.environment.OAUTH_CLIENT_ID`       | Required                                                                         |                                                      |
-| `layer1-port-zenodo.environment.OAUTH_CLIENT_SECRET`   | Required                                                                         |                                                      |
-| `layer1-port-openscienceframework.ADDRESS`             |                                                                                  | https://accounts.test.osf.io                         |
-| `layer1-port-openscienceframework.API_ADDRESS`         |                                                                                  | https://api.test.osf.io/v2                           |
-| `layer1-port-openscienceframework.OAUTH_CLIENT_ID`     | Required                                                                         |                                                      |
-| `layer1-port-openscienceframework.OAUTH_CLIENT_SECRET` | Required                                                                         |                                                      |
-| `layer1-port-owncloud.environment.ADDRESS`             |                                                                                  | https://localhost/owncloud                           |
-| `layer1-port-owncloud.environment.OAUTH_CLIENT_ID`     | Required                                                                         |                                                      |
-| `layer1-port-owncloud.environment.OAUTH_CLIENT_SECRET` | Required                                                                         |                                                      |
-| `<layer3-COMPONENT>.environment.IN_MEMORY_AS_FAILOVER` | If no redis was found, service crashes. With "True" it uses inmemory.            | "False"                                              |
-| `redis`                                                | See [Dependencies](#Dependencies)                                                |                                                      |
-| `jaeger`                                               | See [Dependencies](#Dependencies)                                                |                                                      |
-| `<component>.replicaCount`                             |                                                                                  | 1                                                    |
-| `<component>.image.repository`                         |                                                                                  | `zivgitlab.wwu.io/sciebo-rds/sciebo-rds/<component>` |
-| `<component>.image.tag`                                |                                                                                  | master                                               |
-| `<component>.image.pullPolicy`                         |                                                                                  | Always                                               |
-| `<component>.service.type`                             |                                                                                  | ClusterIP                                            |
-| `<component>.service.port`                             |                                                                                  | 80                                                   |
-| `<component>.service.targetPort`                       |                                                                                  | 8080                                                 |
-| `<component>.service.annotations`                      |                                                                                  | prometheus.io/scrape: "true"                         |
-| `<component>.resources.*`                              | Set Limits and request resources                                                 | {}                                                   |
-| `<component>.nodeSelector.*`                           |                                                                                  | {}                                                   |
-| `<component>.tolerations.*`                            |                                                                                  | []                                                   |
-| `<component>.affinity.*`                               |                                                                                  | {}                                                   |
+| Parameter                                                                   | Description                                                                      | Default / Example                                    |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `global.REDIS_HOST`                                                         | This redis host will be used to store values. Redis-Cluster instance             | redis                                                |
+| `global.REDIS_PORT`                                                         | This redis port will be used to store values. Redis-Cluster instance             | 6379                                                 |
+| `global.REDIS_HELPER_HOST`                                                  | This redis host will be used to store values. Standalone redis (Purpose: Pubsub) | redis                                                |
+| `global.REDIS_HELPER_HOST`                                                  | This redis port will be used to store values. Standalone redis (Purpose: Pubsub) | 6379                                                 |
+| `global.describo.api_secret`                                                | This secret needs to be sent everytime you want to communicate with describo.    | XXX                                                  |
+| `global.describo.domain`                                                    | The domain where describo is located at.                                         | https://describo.localhost.org                       |
+| `global.rds.domain`                                                         | Tehe omain where RDS Web is located at.                                          | https://app.localhost.org                            |
+| `global.ingress.tls.secretName`                                             | The name of the tls secret within k8s.                                           | "sciebords-tls-public"                               |
+| `global.ingress.annotations`                                                | Annotations for ingress. Will be merged with local annotations.                  | {}                                                   |
+| `global.storageClass`                                                       | Can be used to set a global storageClass. Local values will not be overwrite.    | ""                                                   |
+| `layer1-port-zenodo.environment.ADDRESS`                                    |                                                                                  | https://sandbox.zenodo.org                           |
+| `layer1-port-zenodo.environment.ZENODO_OAUTH_CLIENT_ID`                     | Required                                                                         |                                                      |
+| `layer1-port-zenodo.environment.ZENODO_OAUTH_CLIENT_SECRET`                 | Required                                                                         |                                                      |
+| `layer1-port-openscienceframework.ADDRESS`                                  |                                                                                  | https://accounts.test.osf.io                         |
+| `layer1-port-openscienceframework.API_ADDRESS`                              |                                                                                  | https://api.test.osf.io/v2                           |
+| `layer1-port-openscienceframework.OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_ID`     | Required                                                                         |                                                      |
+| `layer1-port-openscienceframework.OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_SECRET` | Required                                                                         |                                                      |
+| `layer1-port-owncloud.environment.ADDRESS`                                  |                                                                                  | https://localhost/owncloud                           |
+| `layer1-port-owncloud.environment.OAUTH_CLIENT_ID`                          | Required                                                                         |                                                      |
+| `layer1-port-owncloud.environment.OAUTH_CLIENT_SECRET`                      | Required                                                                         |                                                      |
+| `<layer3-COMPONENT>.environment.IN_MEMORY_AS_FAILOVER`                      | If no redis was found, service crashes. With "True" it uses inmemory.            | "False"                                              |
+| `redis`                                                                     | See [Dependencies](#Dependencies)                                                |                                                      |
+| `jaeger`                                                                    | See [Dependencies](#Dependencies)                                                |                                                      |
+| `<component>.replicaCount`                                                  |                                                                                  | 1                                                    |
+| `<component>.image.repository`                                              |                                                                                  | `zivgitlab.wwu.io/sciebo-rds/sciebo-rds/<component>` |
+| `<component>.image.tag`                                                     |                                                                                  | master                                               |
+| `<component>.image.pullPolicy`                                              |                                                                                  | Always                                               |
+| `<component>.service.type`                                                  |                                                                                  | ClusterIP                                            |
+| `<component>.service.port`                                                  |                                                                                  | 80                                                   |
+| `<component>.service.targetPort`                                            |                                                                                  | 8080                                                 |
+| `<component>.service.annotations`                                           |                                                                                  | prometheus.io/scrape: "true"                         |
+| `<component>.resources.*`                                                   | Set Limits and request resources                                                 | {}                                                   |
+| `<component>.nodeSelector.*`                                                |                                                                                  | {}                                                   |
+| `<component>.tolerations.*`                                                 |                                                                                  | []                                                   |
+| `<component>.affinity.*`                                                    |                                                                                  | {}                                                   |
 
 
 ##### Connector Branding

--- a/charts/all/Chart.yaml
+++ b/charts/all/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: ">0.2.5"
 description: A single chart for installing whole sciebo rds ecosystem.
 name: all
-version: 0.3.1
+version: 0.3.2
 home: https://www.research-data-services.org/
 type: application
 keywords:
@@ -36,13 +36,13 @@ dependencies:
     tags:
       - layer0
   - name: layer1-port-openscienceframework
-    version: ^0.2.0
+    version: ^0.2.4
     repository: file://../layer1_port_openscienceframework
     condition: layer1-port-openscienceframework.enabled
     tags:
       - layer1
   - name: layer1-port-zenodo
-    version: ^0.2.0
+    version: ^0.2.3
     repository: file://../layer1_port_zenodo
     condition: layer1-port-zenodo.enabled
     tags:

--- a/charts/layer1_port_openscienceframework/Chart.yaml
+++ b/charts/layer1_port_openscienceframework/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: layer1-port-openscienceframework
-version: 0.2.3
+version: 0.2.4
 home: https://www.research-data-services.org/
 type: application
 keywords:

--- a/charts/layer1_port_openscienceframework/templates/configmap.yaml
+++ b/charts/layer1_port_openscienceframework/templates/configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: portosfconfig
   namespace: {{ .Release.Namespace  }}
 data:
-    OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_ID: {{ .Values.environment.OAUTH_CLIENT_ID | quote }}
+    OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_ID: {{ .Values.environment.OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_ID | quote }}
     OPENSCIENCEFRAMEWORK_ADDRESS: {{ .Values.environment.ADDRESS | quote }}
     OPENSCIENCEFRAMEWORK_API_ADDRESS: {{ .Values.environment.API_ADDRESS | quote }}
-    OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_SECRET: {{ .Values.environment.OAUTH_CLIENT_SECRET | quote }}
+    OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_SECRET: {{ .Values.environment.OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_SECRET | quote }}
     OPENSCIENCEFRAMEWORK_DISPLAYNAME: {{ .Values.environment.DISPLAYNAME | quote }}
     OPENSCIENCEFRAMEWORK_INFO_URL: {{ .Values.environment.INFO_URL | quote }}
     OPENSCIENCEFRAMEWORK_HELP_URL: {{ .Values.environment.HELP_URL | quote }}

--- a/charts/layer1_port_openscienceframework/templates/deployment.yaml
+++ b/charts/layer1_port_openscienceframework/templates/deployment.yaml
@@ -24,12 +24,12 @@ spec:
           image: {{ template "layer1_port_openscienceframework.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-          - name: OAUTH_CLIENT_ID
+          - name: OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_ID
             valueFrom:
               secretKeyRef:
                 name: osf-client
                 key: osf-client-id
-          - name: OAUTH_CLIENT_SECRET
+          - name: OPENSCIENCEFRAMEWORK_OAUTH_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
                 name: osf-client

--- a/charts/layer1_port_zenodo/Chart.yaml
+++ b/charts/layer1_port_zenodo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: layer1-port-zenodo
-version: 0.2.2
+version: 0.2.3
 home: https://www.research-data-services.org/
 type: application
 keywords:

--- a/charts/layer1_port_zenodo/templates/configmap.yaml
+++ b/charts/layer1_port_zenodo/templates/configmap.yaml
@@ -4,9 +4,9 @@ metadata:
   name: portzenodoconfig
   namespace: {{ .Release.Namespace }}
 data:
-  ZENODO_OAUTH_CLIENT_ID: {{ .Values.environment.OAUTH_CLIENT_ID | quote }}
+  ZENODO_OAUTH_CLIENT_ID: {{ .Values.environment.ZENODO_OAUTH_CLIENT_ID | quote }}
   ZENODO_ADDRESS: {{ .Values.environment.ADDRESS | quote }}
-  ZENODO_OAUTH_CLIENT_SECRET: {{ .Values.environment.OAUTH_CLIENT_SECRET | quote }}
+  ZENODO_OAUTH_CLIENT_SECRET: {{ .Values.environment.ZENODO_OAUTH_CLIENT_SECRET | quote }}
   ZENODO_DISPLAYNAME: {{ .Values.environment.DISPLAYNAME | quote }}
   ZENODO_INFO_URL: {{ .Values.environment.INFO_URL | quote }}
   ZENODO_HELP_URL: {{ .Values.environment.HELP_URL | quote }}

--- a/charts/layer1_port_zenodo/templates/deployment.yaml
+++ b/charts/layer1_port_zenodo/templates/deployment.yaml
@@ -24,12 +24,12 @@ spec:
           image: {{ template "layer1_port_zenodo.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-          - name: OAUTH_CLIENT_ID
+          - name: ZENODO_OAUTH_CLIENT_ID
             valueFrom:
               secretKeyRef:
                 name: zenodo-client
                 key: zenodo-client-id
-          - name: OAUTH_CLIENT_SECRET
+          - name: ZENODO_OAUTH_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
                 name: zenodo-client


### PR DESCRIPTION
This patch harmonizes the names of the env variables to match what is used in the python code;

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
