### PR TITLE
Allow layer1-port-owncloud to distinguish between nextcloud and owncloud

### DIFF
--- a/charts/layer1_port_owncloud/templates/configmap.yaml
+++ b/charts/layer1_port_owncloud/templates/configmap.yaml
@@ -32,4 +32,10 @@ data:
   {{ if .INTERNAL_ADDRESS }}
   OWNCLOUD_INTERNAL_INSTALLATION_URL: {{ .INTERNAL_ADDRESS | quote }}
   {{ end }}
+  {{ if not .EFSS }}
+  EFSS_SYSTEM: "owncloud"
+  {{ end }}
+  {{ if .EFSS }}
+  EFSS_SYSTEM: {{ .EFSS | quote }}
+  {{ end }}
 {{- end }}

--- a/charts/layer1_port_owncloud/values.yaml
+++ b/charts/layer1_port_owncloud/values.yaml
@@ -36,6 +36,7 @@ environment:
   INFO_URL: ""
   HELP_URL: ""
   ICON: ""
+  EFSS: "owncloud"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
New environment variable to allow layer1-port-owncloud to distinguish between nextcloud and owncloud

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
